### PR TITLE
Adiciona teste para converter lista de modelos

### DIFF
--- a/src/test/java/br/com/alura/tabelafipe/TabelafipeApplicationTests.java
+++ b/src/test/java/br/com/alura/tabelafipe/TabelafipeApplicationTests.java
@@ -1,13 +1,38 @@
 package br.com.alura.tabelafipe;
 
+import br.com.alura.tabelafipe.model.Dados;
+import br.com.alura.tabelafipe.service.ConverteDados;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
 class TabelafipeApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @Test
+    void contextLoads() {
+    }
+
+    @Test
+    void testConverteDadosObterLista() {
+        String json = """
+                [
+                  {"codigo": "1", "nome": "Modelo A"},
+                  {"codigo": "2", "nome": "Modelo B"}
+                ]
+                """;
+
+        ConverteDados conversor = new ConverteDados();
+        List<Dados> dados = conversor.obterLista(json, Dados.class);
+
+        assertEquals(2, dados.size());
+        assertEquals("1", dados.get(0).codigo());
+        assertEquals("Modelo A", dados.get(0).nome());
+        assertEquals("2", dados.get(1).codigo());
+        assertEquals("Modelo B", dados.get(1).nome());
+    }
 
 }


### PR DESCRIPTION
## Summary
- adiciona teste unitário `testConverteDadosObterLista` verificando a conversão de JSON para lista de `Dados`

## Testing
- `mvn -q test` *(falhou: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.4 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68a5fc3b06b48333b076065c9b639fd0