### PR TITLE
Configure JavaFX plugin to use MainApplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Tabela Fipe
+
+Projeto de consulta à Tabela Fipe.
+
+## Executar GUI
+
+Para iniciar a interface gráfica, utilize o comando:
+
+```bash
+mvn javafx:run
+```
+

--- a/pom.xml
+++ b/pom.xml
@@ -50,13 +50,21 @@
 
 
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
+        <build>
+                <plugins>
+                        <plugin>
+                                <groupId>org.openjfx</groupId>
+                                <artifactId>javafx-maven-plugin</artifactId>
+                                <version>0.0.8</version>
+                                <configuration>
+                                        <mainClass>br.com.alura.tabelafipe.MainApplication</mainClass>
+                                </configuration>
+                        </plugin>
+                        <plugin>
+                                <groupId>org.springframework.boot</groupId>
+                                <artifactId>spring-boot-maven-plugin</artifactId>
+                        </plugin>
+                </plugins>
+        </build>
 
 </project>


### PR DESCRIPTION
## Summary
- point `javafx-maven-plugin` at `MainApplication`
- document how to start the GUI with `mvn javafx:run`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for br.com.alura:tabelafipe:0.0.1-SNAPSHOT: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.4 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68a5fc54f6d4833391a1d8b7b8558542