### PR TITLE
Refactor JSON conversion to use static mapper

### DIFF
--- a/src/main/java/br/com/alura/tabelafipe/service/ConverteDados.java
+++ b/src/main/java/br/com/alura/tabelafipe/service/ConverteDados.java
@@ -1,18 +1,20 @@
 package br.com.alura.tabelafipe.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.CollectionType;
 
 import java.util.List;
 
 public class ConverteDados implements IConverteDados {
-    private ObjectMapper mapper = new ObjectMapper();
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
     @Override
     public <T> T obterDados(String json, Class<T> classe) {
         try {
-            return mapper.readValue(json, classe);
+            return MAPPER.readValue(json, classe);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
@@ -20,12 +22,12 @@ public class ConverteDados implements IConverteDados {
 
     @Override
     public <T> List<T> obterLista(String json, Class<T> classe) {
-        CollectionType lista = mapper.getTypeFactory()
+        CollectionType lista = MAPPER.getTypeFactory()
                 .constructCollectionType(List.class, classe);
 
 
         try {
-            return mapper.readValue(json, lista);
+            return MAPPER.readValue(json, lista);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
## Summary
- introduce a shared ObjectMapper configured to ignore unknown properties
- replace per-instance mapper usage with the new constant

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68a5ff2df65883339cc03f532992f12b