### PR TITLE
test: add service tests for API and JSON conversion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,12 +41,19 @@
 			<scope>test</scope>
 		</dependency>
 
-		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-databind</artifactId>
-			<version>2.15.2</version>
-		</dependency>
-	</dependencies>
+                <dependency>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-databind</artifactId>
+                        <version>2.15.2</version>
+                </dependency>
+                
+                <dependency>
+                        <groupId>com.squareup.okhttp3</groupId>
+                        <artifactId>mockwebserver</artifactId>
+                        <version>4.11.0</version>
+                        <scope>test</scope>
+                </dependency>
+        </dependencies>
 
 
 

--- a/src/test/java/br/com/alura/tabelafipe/service/ConsumoAPITest.java
+++ b/src/test/java/br/com/alura/tabelafipe/service/ConsumoAPITest.java
@@ -1,0 +1,32 @@
+package br.com.alura.tabelafipe.service;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ConsumoAPITest {
+
+    @Test
+    void deveRetornarJsonDaAPI() throws Exception {
+        String expectedJson = "{\"mensagem\":\"ok\"}";
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse().setBody(expectedJson).setResponseCode(200));
+            server.start();
+
+            ConsumoAPI consumoAPI = new ConsumoAPI();
+            String url = server.url("/dados").toString();
+            String json = consumoAPI.obterDados(url);
+
+            assertEquals(expectedJson, json);
+        }
+    }
+
+    @Test
+    void deveLancarExcecaoQuandoServidorInacessivel() {
+        ConsumoAPI consumoAPI = new ConsumoAPI();
+        String url = "http://localhost:9999/inexistente";
+        assertThrows(RuntimeException.class, () -> consumoAPI.obterDados(url));
+    }
+}

--- a/src/test/java/br/com/alura/tabelafipe/service/ConverteDadosTest.java
+++ b/src/test/java/br/com/alura/tabelafipe/service/ConverteDadosTest.java
@@ -1,0 +1,43 @@
+package br.com.alura.tabelafipe.service;
+
+import br.com.alura.tabelafipe.model.Dados;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ConverteDadosTest {
+
+    private final ConverteDados converte = new ConverteDados();
+
+    @Test
+    void deveConverterJsonEmObjetoDados() throws Exception {
+        String json = "{\"codigo\":\"01\",\"nome\":\"Fiat\"}";
+        Dados esperado = new Dados("01", "Fiat");
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse().setBody(json).setResponseCode(200));
+            server.start();
+            ConsumoAPI consumoAPI = new ConsumoAPI();
+            String resposta = consumoAPI.obterDados(server.url("/dados").toString());
+            Dados dados = converte.obterDados(resposta, Dados.class);
+            assertEquals(esperado, dados);
+        }
+    }
+
+    @Test
+    void deveConverterJsonEmListaDeDados() {
+        String json = "[{\"codigo\":\"01\",\"nome\":\"Fiat\"},{\"codigo\":\"02\",\"nome\":\"Ford\"}]";
+        List<Dados> dados = converte.obterLista(json, Dados.class);
+        assertEquals(2, dados.size());
+        assertEquals(new Dados("01", "Fiat"), dados.get(0));
+    }
+
+    @Test
+    void deveLancarExcecaoParaJsonInvalido() {
+        String jsonInvalido = "{codigo:semAspas}";
+        assertThrows(RuntimeException.class, () -> converte.obterDados(jsonInvalido, Dados.class));
+    }
+}


### PR DESCRIPTION
## Summary
- add mock web server dependency for testing
- test ConsumoAPI behavior on success and failure scenarios
- test ConverteDados JSON parsing and error handling

## Testing
- `mvn test` *(fails: Non-resolvable parent POM for br.com.alura:tabelafipe:0.0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_b_68a5ff2e36308333a8f2ed62b75b7c8a