### PR TITLE
Remove unnecessary Jackson dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,11 +41,6 @@
 			<scope>test</scope>
 		</dependency>
 
-		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-databind</artifactId>
-			<version>2.15.2</version>
-		</dependency>
 	</dependencies>
 
 


### PR DESCRIPTION
## Summary
- remove explicit jackson-databind dependency from pom

## Testing
- `mvn test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.4)*

------
https://chatgpt.com/codex/tasks/task_b_68a5ff314bd48333a28ad079b5778f6b