### PR TITLE
Add TipoVeiculo enum and input validation

### DIFF
--- a/src/main/java/br/com/alura/tabelafipe/model/TipoVeiculo.java
+++ b/src/main/java/br/com/alura/tabelafipe/model/TipoVeiculo.java
@@ -1,0 +1,17 @@
+package br.com.alura.tabelafipe.model;
+
+public enum TipoVeiculo {
+    CARRO("carros"),
+    MOTO("motos"),
+    CAMINHAO("caminhoes");
+
+    private final String tipo;
+
+    TipoVeiculo(String tipo) {
+        this.tipo = tipo;
+    }
+
+    public String getTipo() {
+        return tipo;
+    }
+}

--- a/src/main/java/br/com/alura/tabelafipe/principal/Principal.java
+++ b/src/main/java/br/com/alura/tabelafipe/principal/Principal.java
@@ -2,6 +2,7 @@ package br.com.alura.tabelafipe.principal;
 
 import br.com.alura.tabelafipe.model.Dados;
 import br.com.alura.tabelafipe.model.Modelos;
+import br.com.alura.tabelafipe.model.TipoVeiculo;
 import br.com.alura.tabelafipe.model.Veiculo;
 import br.com.alura.tabelafipe.service.ConsumoAPI;
 import br.com.alura.tabelafipe.service.ConverteDados;
@@ -32,15 +33,14 @@ public class Principal {
 
         System.out.println(menu);
         var opcao = leitura.nextLine();
-        String endereco;
-
-        if (opcao.toLowerCase().contains("carr")) {
-            endereco = URL_BASE + "carros/marcas";
-        } else if (opcao.toLowerCase().contains("mot")) {
-            endereco = URL_BASE + "motos/marcas";
-        } else {
-            endereco = URL_BASE + "caminhos/marcas";
+        TipoVeiculo tipoVeiculo;
+        try {
+            tipoVeiculo = TipoVeiculo.valueOf(opcao.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            System.out.println("Opção inválida");
+            return;
         }
+        String endereco = URL_BASE + tipoVeiculo.getTipo() + "/marcas";
         var json = consumo.obterDados(endereco);
         System.out.println(json);
         var marcas = conversor.obterLista(json, Dados.class);


### PR DESCRIPTION
## Summary
- add TipoVeiculo enum for supported vehicle types
- update menu logic to parse user input via enum with validation

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68a5ff3e1b3c83338a9a484cdd6ed00f