### PR TITLE
Add CORS configuration via WebMvcConfigurer

### DIFF
--- a/src/main/java/br/com/alura/tabelafipe/config/WebConfig.java
+++ b/src/main/java/br/com/alura/tabelafipe/config/WebConfig.java
@@ -1,0 +1,17 @@
+package br.com.alura.tabelafipe.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:3000")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*");
+    }
+}


### PR DESCRIPTION
## Summary
- add global CORS mapping allowing requests from `http://localhost:3000`

## Testing
- `./mvnw -q test` *(failed: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip)*
- `mvn -q test` *(failed: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.4 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68a603b0a334833396359c39e258d082