### PR TITLE
Add Bootstrap layout with responsive components and theme toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ build/
 
 ### VS Code ###
 .vscode/
+
+# Node
+node_modules/
+dist/

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="pt-BR" data-bs-theme="light">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tabela Fipe</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./src/main.js"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node test/components.test.js"
+  }
+}

--- a/frontend/src/components/Footer.js
+++ b/frontend/src/components/Footer.js
@@ -1,0 +1,9 @@
+export function Footer() {
+  return `
+    <footer class="bg-light mt-auto text-center py-3 border-top">
+      <div class="container">
+        <span class="text-muted">&copy; 2025 Tabela Fipe</span>
+      </div>
+    </footer>
+  `;
+}

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -1,0 +1,10 @@
+export function Header() {
+  return `
+    <header class="bg-primary text-white">
+      <nav class="navbar navbar-expand container">
+        <a class="navbar-brand" href="#">Tabela Fipe</a>
+        <button class="btn btn-outline-light ms-auto" id="theme-toggle">Tema</button>
+      </nav>
+    </header>
+  `;
+}

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,0 +1,14 @@
+import { Header } from './Header.js';
+import { Footer } from './Footer.js';
+
+export function Layout(content) {
+  return `
+    <div class="d-flex flex-column min-vh-100">
+      ${Header()}
+      <main class="container flex-fill py-4">
+        ${content}
+      </main>
+      ${Footer()}
+    </div>
+  `;
+}

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,0 +1,9 @@
+import { Layout } from './components/Layout.js';
+
+const app = document.getElementById('app');
+app.innerHTML = Layout('<p>Conteúdo principal</p>');
+
+document.getElementById('theme-toggle').addEventListener('click', () => {
+  const html = document.documentElement;
+  html.dataset.bsTheme = html.dataset.bsTheme === 'light' ? 'dark' : 'light';
+});

--- a/frontend/test/components.test.js
+++ b/frontend/test/components.test.js
@@ -1,0 +1,12 @@
+import assert from 'assert';
+import { Header } from '../src/components/Header.js';
+import { Footer } from '../src/components/Footer.js';
+import { Layout } from '../src/components/Layout.js';
+
+assert.ok(Header().includes('navbar'), 'Header should contain navbar');
+assert.ok(Footer().includes('<footer'), 'Footer should render footer tag');
+const layout = Layout('<div>body</div>');
+assert.ok(layout.includes('navbar'), 'Layout should include Header');
+assert.ok(layout.includes('<footer'), 'Layout should include Footer');
+
+console.log('All component tests passed');


### PR DESCRIPTION
## Summary
- integrate Bootstrap via CDN and add basic frontend
- provide Header, Footer, and Layout components with dark/light toggle
- ensure responsive flex/grid layout and basic tests for components

## Testing
- `npm test --prefix frontend`
- `mvn -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_b_68a607dd74348333882237300364b117